### PR TITLE
Restore IBC Tx unmarshaling capabilities

### DIFF
--- a/grpc_cosmos_sdk_v44.go
+++ b/grpc_cosmos_sdk_v44.go
@@ -17,7 +17,6 @@ import (
 	sdkutilities "github.com/allinbits/sdk-service-meta/gen/sdk_utilities"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/simapp"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
@@ -25,6 +24,7 @@ import (
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distribution "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	mint "github.com/cosmos/cosmos-sdk/x/mint/types"
+	gaia "github.com/cosmos/gaia/v6/app"
 	liquidity "github.com/gravity-devs/liquidity/x/liquidity/types"
 	"github.com/tendermint/tendermint/abci/types"
 	"google.golang.org/grpc"
@@ -41,7 +41,7 @@ const (
 )
 
 func initCodec() {
-	cfg := simapp.MakeTestEncodingConfig()
+	cfg := gaia.MakeEncodingConfig()
 	cdc = cfg.Marshaler
 }
 


### PR DESCRIPTION
This PR addresses an issue we were having with IBC transactions:

```json
{
  "id": "394217638231803604",
  "namespace": "chains",
  "cause": "cannot retrieve tx from sdk-service, rpc error: code = Unknown desc = unable to resolve type URL /ibc.applications.transfer.v1.MsgTransfer"
}
```

We were unable to unmarshal Tx's containing IBC messages because our v44 codec did not have IBC definitions inside of it.

Why? Because we were including Terra core libs, which in turn use an unsupported version of IBC, v1.

Due to the weird nature of Google's protobuf library design, one cannot register a type two times, since Gaia and Terra do _exactly that_, we had to make a choice: drop Gaia's codec in favor of keeping Terra compatibility.

To do that we replaced Gaia's codec with the `simapp`'s one, but we forgot that since Cosmos SDK v44, IBC now lives under its own repo, and the `simapp` codec doesn't understand IBC.

The fix here is:
 - reintroduce Gaia's codec
 - move Terra tax computation over their REST API, with no direct dependency on anything Terra-related.