### PR TITLE
Move from allinbits to EmerisHQ

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ replace (
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )
 
-require goa.design/goa/v3 v3.5.2
-
 require (
-	github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc
+	github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c // indirect
+	goa.design/goa/v3 v3.5.5
 )

--- a/mods/go.mod.bare
+++ b/mods/go.mod.bare
@@ -7,8 +7,7 @@ replace (
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )
 
-require goa.design/goa/v3 v3.5.2
-
 require (
-	github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc
+	github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c // indirect
+	goa.design/goa/v3 v3.5.5
 )

--- a/mods/go.mod.v42
+++ b/mods/go.mod.v42
@@ -10,12 +10,12 @@ replace (
 require goa.design/goa/v3 v3.5.5
 
 require (
-	github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc
 	github.com/armon/go-metrics v0.3.9 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cosmos/cosmos-sdk v0.42.10
 	github.com/cosmos/gaia/v5 v5.0.8
+	github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/mods/go.mod.v44
+++ b/mods/go.mod.v44
@@ -10,10 +10,10 @@ replace (
 require goa.design/goa/v3 v3.5.5
 
 require (
-	github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc
 	github.com/cosmos/cosmos-sdk v0.44.5
 	github.com/cosmos/gaia/v6 v6.0.0-rc3
 	github.com/cosmos/ibc-go/v2 v2.0.0
+	github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/mods/go.sum.v42
+++ b/mods/go.sum.v42
@@ -76,12 +76,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41 h1:gW30y7jNDSvEIvRIIGi+az5YQkjUz3PusxEraBLssh8=
-github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
-github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27 h1:7HQKXS3wg2EXMh6l7/1hrCec7dwukvizvh+g2zU+/mo=
-github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
-github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc h1:RYkjiawhVW5kyGedO87fhoJ/B+mPKz3UbMWyCtfoJHU=
-github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc/go.mod h1:1qjnoOm6sxbMQp2uIMi2EaVIjAazPyom5HNUlGPZdAw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -232,6 +226,14 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41 h1:gW30y7jNDSvEIvRIIGi+az5YQkjUz3PusxEraBLssh8=
+github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
+github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27 h1:7HQKXS3wg2EXMh6l7/1hrCec7dwukvizvh+g2zU+/mo=
+github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
+github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc h1:RYkjiawhVW5kyGedO87fhoJ/B+mPKz3UbMWyCtfoJHU=
+github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc/go.mod h1:1qjnoOm6sxbMQp2uIMi2EaVIjAazPyom5HNUlGPZdAw=
+github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c h1:cFuGwd6B3zFBHHrIiA2ZQhPwfX2L2I8Nyd+TyWnWhKU=
+github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c/go.mod h1:WobTsokN58o+aUSae8Jbo6rvs5xID+0i7+tqXixo+CQ=
 github.com/enigmampc/btcutil v1.0.3-0.20200723161021-e2fb6adb2a25 h1:2vLKys4RBU4pn2T/hjXMbvwTr1Cvy5THHrQkbeY9HRk=
 github.com/enigmampc/btcutil v1.0.3-0.20200723161021-e2fb6adb2a25/go.mod h1:hTr8+TLQmkUkgcuh3mcr5fjrT9c64ZzsBCdCEC6UppY=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/mods/go.sum.v44
+++ b/mods/go.sum.v44
@@ -93,12 +93,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
-github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41 h1:gW30y7jNDSvEIvRIIGi+az5YQkjUz3PusxEraBLssh8=
-github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
-github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27 h1:7HQKXS3wg2EXMh6l7/1hrCec7dwukvizvh+g2zU+/mo=
-github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
-github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc h1:RYkjiawhVW5kyGedO87fhoJ/B+mPKz3UbMWyCtfoJHU=
-github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc/go.mod h1:1qjnoOm6sxbMQp2uIMi2EaVIjAazPyom5HNUlGPZdAw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -267,6 +261,14 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41 h1:gW30y7jNDSvEIvRIIGi+az5YQkjUz3PusxEraBLssh8=
+github.com/emerishq/sdk-service-meta v0.0.0-20211216152128-81bcba908a41/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
+github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27 h1:7HQKXS3wg2EXMh6l7/1hrCec7dwukvizvh+g2zU+/mo=
+github.com/emerishq/sdk-service-meta v0.0.0-20220114142340-a44e073d0b27/go.mod h1:ZOehmlZy3nTRgpDE6hImQ5TzwXF8B4QIypYzOMgcO4Q=
+github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc h1:RYkjiawhVW5kyGedO87fhoJ/B+mPKz3UbMWyCtfoJHU=
+github.com/emerishq/sdk-service-meta v0.0.0-20220225122854-eb00092170cc/go.mod h1:1qjnoOm6sxbMQp2uIMi2EaVIjAazPyom5HNUlGPZdAw=
+github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c h1:cFuGwd6B3zFBHHrIiA2ZQhPwfX2L2I8Nyd+TyWnWhKU=
+github.com/emerishq/sdk-service-meta v0.0.0-20220308092725-c969850e820c/go.mod h1:WobTsokN58o+aUSae8Jbo6rvs5xID+0i7+tqXixo+CQ=
 github.com/enigmampc/btcutil v1.0.3-0.20200723161021-e2fb6adb2a25/go.mod h1:hTr8+TLQmkUkgcuh3mcr5fjrT9c64ZzsBCdCEC6UppY=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=


### PR DESCRIPTION
This repo was still pointing to the old `sdk-service-meta` repo. Updated that.