### PR TITLE
Refactor custom mint module functions

### DIFF
--- a/grpc_cosmos_sdk_v44.go
+++ b/grpc_cosmos_sdk_v44.go
@@ -415,17 +415,12 @@ func MintInflation(chainName string, port *int) (sdkutilities.MintInflation2, er
 		}
 		reductionPeriodInEpochs := mintParamsResp.GetParams().ReductionPeriodInEpochs
 
-		osmosisStakingDenom := "uosmo"
-		supplyRes, err := SupplyDenom(chainName, port, &osmosisStakingDenom)
+		bankQuery := bank.NewQueryClient(grpcConn)
+		suppRes, err := bankQuery.SupplyOf(context.Background(), &bank.QuerySupplyOfRequest{Denom: mintParamsResp.GetParams().MintDenom})
 		if err != nil {
 			return sdkutilities.MintInflation2{}, err
 		}
-
-		coin, err := sdktypes.ParseCoinNormalized(supplyRes.Coins[0].Amount)
-		if err != nil {
-			return sdkutilities.MintInflation2{}, err
-		}
-		supply := coin.Amount.Uint64()
+		supply := suppRes.GetAmount().Amount.Uint64()
 
 		inflation := (epochProvisions * float64(reductionPeriodInEpochs)) / float64(supply)
 		ret := sdkutilities.MintInflation2{


### PR DESCRIPTION
The current implementation uses `if conditions` to check for chain which have custom mint modules and then follows a different set of operations. 
Going forward there might be many such chains which will implement custom modules and the "if" approach might not be the optimal way to go.
I have considered a map[string]func() which maps a chain name to the required functions.

Please do suggest if you have any better ideas to solve this.